### PR TITLE
Changed for consistency value in custom_rules and manifest that didn'…

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -7,8 +7,8 @@
     <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="22"/>
 
     <!-- Permissions for Push Notification -->
-    <permission android:name="org.linphone.vtcsecure.permission.C2D_MESSAGE" android:protectionLevel="signature" /> <!-- Change package ! -->
-	<uses-permission android:name="org.linphone.vtcsecure.permission.C2D_MESSAGE" />  <!-- Change package ! -->
+    <permission android:name="com.vtcsecure.ace.permission.C2D_MESSAGE" android:protectionLevel="signature" /> <!-- Change package ! -->
+	<uses-permission android:name="com.vtcsecure.ace.permission.C2D_MESSAGE" />  <!-- Change package ! -->
 	<uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/custom_rules.xml
+++ b/custom_rules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="custom_rules">
 
-	<property name="linphone.package.name" value="org.linphone.vtcsecure" />
+	<property name="linphone.package.name" value="com.vtcsecure.ace" />
 
     <!-- Maven ant task for dependencies -->
     <!--


### PR DESCRIPTION
…t conflict. Changing the package name in the manifest however caused resource location issues so it was left as "org.linphone". The permissions settings were also changed also according to the readme for push notifications, however it's not yet known if there will be a conflict when those are implemented.
