### PR TITLE
Improved the RTT UI for video-enabled calls

### DIFF
--- a/res/layout-land/incall.xml
+++ b/res/layout-land/incall.xml
@@ -53,11 +53,83 @@
         android:layout_alignParentTop="true"
         android:layout_centerHorizontal="true"
         android:layout_marginBottom="100dp" />
+
     <LinearLayout
+        android:id="@+id/rtt_container"
+        android:visibility="gone"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:layout_alignParentBottom="true">
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentRight="true">
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:weightSum="2">
+
+            <TextView
+                android:id="@+id/partner_name"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="center"
+                style="@style/RttHeaderTextStyle" />
+
+            <View
+                android:layout_width="3dp"
+                android:layout_height="match_parent"/>
+
+            <TextView
+                android:id="@+id/user_name"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="center"
+                style="@style/RttHeaderTextStyle" />
+        </LinearLayout>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+            <TextView
+                android:id="@+id/rtt_incoming_view"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:layout_weight="1"
+                android:background="#B0000000"
+                android:singleLine="false"
+                android:scrollbars="vertical"
+                android:paddingLeft="2dp"
+                android:paddingRight="2dp"
+                style="@style/RttTextStyle"/>
+            <View
+                android:layout_width="3dp"
+                android:layout_height="match_parent"
+                android:background="@android:color/white"/>
+            <TextView
+                android:id="@+id/rtt_outgoing_view"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:layout_weight="1"
+                android:background="#B0000000"
+                android:singleLine="false"
+                android:scrollbars="vertical"
+                android:paddingLeft="2dp"
+                android:paddingRight="2dp"
+                style="@style/RttTextStyle"/>
+        </LinearLayout>
+        <EditText
+            android:id="@+id/rtt_input_field"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:singleLine="true"
+            android:background="@android:color/black"
+            android:textColor="@android:color/white"/>
+    </LinearLayout>
+
     <LinearLayout
         android:id="@+id/menu"
         android:layout_width="match_parent"
@@ -252,85 +324,7 @@
             android:background="@drawable/dialer_alt"
           	android:gravity="center"
             android:paddingTop="30dp" />
-
-
-           
-       </LinearLayout>
-        <LinearLayout
-            android:id="@+id/rtt_container"
-            android:visibility="gone"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-	        <LinearLayout
-		        android:layout_width="match_parent"
-		        android:layout_height="wrap_content"
-		        android:orientation="horizontal"
-		        android:weightSum="2">
-
-		        <TextView
-			        android:id="@+id/partner_name"
-			        android:layout_width="0dp"
-			        android:layout_height="wrap_content"
-			        android:layout_weight="1"
-			        android:gravity="center"
-			        android:textColor="@android:color/black"
-			        android:textSize="14sp"
-			        android:textStyle="bold"/>
-
-		        <View
-			        android:layout_width="3dp"
-			        android:layout_height="match_parent"/>
-
-		        <TextView
-			        android:id="@+id/user_name"
-			        android:layout_width="0dp"
-			        android:layout_height="wrap_content"
-			        android:layout_weight="1"
-			        android:gravity="center"
-			        android:textColor="@android:color/black"
-			        android:textSize="14sp"
-			        android:textStyle="bold"/>
-	        </LinearLayout>
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
-                <TextView
-                    android:id="@+id/rtt_incoming_view"
-                    android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:layout_weight="1"
-                    android:background="@android:color/black"
-                    android:textColor="@android:color/white"
-                    android:singleLine="false"
-                    android:scrollbars="vertical"
-	                android:paddingLeft="2dp"
-	                android:paddingRight="2dp"/>
-	            <View
-		            android:layout_width="3dp"
-		            android:layout_height="match_parent"
-		            android:background="@android:color/white"/>
-                <TextView
-                    android:id="@+id/rtt_outgoing_view"
-                    android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:layout_weight="1"
-                    android:background="@android:color/black"
-                    android:textColor="@android:color/white"
-                    android:singleLine="false"
-                    android:scrollbars="vertical"
-	                android:paddingLeft="2dp"
-	                android:paddingRight="2dp"/>
-            </LinearLayout>
-            <EditText
-                android:id="@+id/rtt_input_field"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:singleLine="true"
-	            android:textColor="@android:color/black"/>
-        </LinearLayout>
+        
     </LinearLayout>
 
 </RelativeLayout>

--- a/res/layout-small/incall.xml
+++ b/res/layout-small/incall.xml
@@ -53,6 +53,82 @@
         android:layout_centerVertical="true" />
 
     <LinearLayout
+        android:id="@+id/rtt_container"
+        android:visibility="gone"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentRight="true">
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:weightSum="2">
+
+            <TextView
+                android:id="@+id/partner_name"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="center"
+                style="@style/RttHeaderTextStyle" />
+
+            <View
+                android:layout_width="3dp"
+                android:layout_height="match_parent"/>
+
+            <TextView
+                android:id="@+id/user_name"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="center"
+                style="@style/RttHeaderTextStyle" />
+        </LinearLayout>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+            <TextView
+                android:id="@+id/rtt_incoming_view"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:layout_weight="1"
+                android:background="#B0000000"
+                android:singleLine="false"
+                android:scrollbars="vertical"
+                android:paddingLeft="2dp"
+                android:paddingRight="2dp"
+                style="@style/RttTextStyle"/>
+            <View
+                android:layout_width="3dp"
+                android:layout_height="match_parent"
+                android:background="@android:color/white"/>
+            <TextView
+                android:id="@+id/rtt_outgoing_view"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:layout_weight="1"
+                android:background="#B0000000"
+                android:singleLine="false"
+                android:scrollbars="vertical"
+                android:paddingLeft="2dp"
+                android:paddingRight="2dp"
+                style="@style/RttTextStyle"/>
+        </LinearLayout>
+        <EditText
+            android:id="@+id/rtt_input_field"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:singleLine="true"
+            android:background="@android:color/black"
+            android:textColor="@android:color/white"/>
+    </LinearLayout>
+
+    <LinearLayout
         android:id="@+id/menu"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -259,82 +335,6 @@
             
         </LinearLayout>
 
-        <LinearLayout
-            android:id="@+id/rtt_container"
-            android:visibility="gone"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-	        <LinearLayout
-		        android:layout_width="match_parent"
-		        android:layout_height="wrap_content"
-		        android:orientation="horizontal"
-		        android:weightSum="2">
-
-		        <TextView
-			        android:id="@+id/partner_name"
-			        android:layout_width="0dp"
-			        android:layout_height="wrap_content"
-			        android:layout_weight="1"
-			        android:gravity="center"
-			        android:textColor="@android:color/white"
-			        android:textSize="14sp"
-			        android:textStyle="bold"/>
-
-		        <View
-			        android:layout_width="3dp"
-			        android:layout_height="match_parent"/>
-
-		        <TextView
-			        android:id="@+id/user_name"
-			        android:layout_width="0dp"
-			        android:layout_height="wrap_content"
-			        android:layout_weight="1"
-			        android:gravity="center"
-			        android:textColor="@android:color/white"
-			        android:textSize="14sp"
-			        android:textStyle="bold"/>
-	        </LinearLayout>
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
-                <TextView
-                    android:id="@+id/rtt_incoming_view"
-                    android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:layout_weight="1"
-                    android:background="@android:color/black"
-                    android:textColor="@android:color/white"
-                    android:singleLine="false"
-                    android:scrollbars="vertical"
-                    android:paddingLeft="2dp"
-	                android:paddingRight="2dp"/>
-	            <View
-		            android:layout_width="3dp"
-		            android:layout_height="match_parent"
-		            android:background="@android:color/white"/>
-                <TextView
-                    android:id="@+id/rtt_outgoing_view"
-                    android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:layout_weight="1"
-                    android:background="@android:color/black"
-                    android:textColor="@android:color/white"
-                    android:singleLine="false"
-                    android:scrollbars="vertical"
-	                android:paddingLeft="2dp"
-	                android:paddingRight="2dp"/>
-            </LinearLayout>
-            <EditText
-                android:id="@+id/rtt_input_field"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:singleLine="true"
-	            android:textColor="@android:color/white"/>
-        </LinearLayout>
-        
     </LinearLayout>
 
 </RelativeLayout>

--- a/res/layout-sw533dp-land/incall.xml
+++ b/res/layout-sw533dp-land/incall.xml
@@ -41,6 +41,82 @@
         android:layout_marginTop="40dp"
         android:visibility="invisible"
         android:src="@drawable/switch_camera" />
+
+	<LinearLayout
+		android:id="@+id/rtt_container"
+		android:visibility="gone"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:orientation="vertical"
+		android:layout_alignParentBottom="true"
+		android:layout_alignParentLeft="true"
+		android:layout_alignParentRight="true">
+		<LinearLayout
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:orientation="horizontal"
+			android:weightSum="2">
+
+			<TextView
+				android:id="@+id/partner_name"
+				android:layout_width="0dp"
+				android:layout_height="wrap_content"
+				android:layout_weight="1"
+				android:gravity="center"
+				style="@style/RttHeaderTextStyle" />
+
+			<View
+				android:layout_width="3dp"
+				android:layout_height="match_parent"/>
+
+			<TextView
+				android:id="@+id/user_name"
+				android:layout_width="0dp"
+				android:layout_height="wrap_content"
+				android:layout_weight="1"
+				android:gravity="center"
+				style="@style/RttHeaderTextStyle" />
+		</LinearLayout>
+		<LinearLayout
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:orientation="horizontal">
+			<TextView
+				android:id="@+id/rtt_incoming_view"
+				android:layout_width="match_parent"
+				android:layout_height="100dp"
+				android:layout_weight="1"
+				android:background="#B0000000"
+				android:singleLine="false"
+				android:scrollbars="vertical"
+				android:paddingLeft="2dp"
+				android:paddingRight="2dp"
+				style="@style/RttTextStyle"/>
+			<View
+				android:layout_width="3dp"
+				android:layout_height="match_parent"
+				android:background="@android:color/white"/>
+			<TextView
+				android:id="@+id/rtt_outgoing_view"
+				android:layout_width="match_parent"
+				android:layout_height="100dp"
+				android:layout_weight="1"
+				android:background="#B0000000"
+				android:singleLine="false"
+				android:scrollbars="vertical"
+				android:paddingLeft="2dp"
+				android:paddingRight="2dp"
+				style="@style/RttTextStyle"/>
+		</LinearLayout>
+		<EditText
+			android:id="@+id/rtt_input_field"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:layout_weight="1"
+			android:singleLine="true"
+			android:background="@android:color/black"
+			android:textColor="@android:color/white"/>
+	</LinearLayout>
     
     <org.linphone.ui.Numpad
         android:id="@+id/numpad"
@@ -148,86 +224,6 @@
 	            android:textColor="@drawable/text_incall_button_color" />
 	        
 	    </LinearLayout>
-
-		<LinearLayout
-			android:id="@+id/rtt_container"
-			android:visibility="gone"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			android:orientation="vertical"
-			android:layout_alignParentBottom="true"
-			android:layout_toRightOf="@+id/left_menu"
-			android:layout_toLeftOf="@+id/linearLayout"
-			android:layout_toStartOf="@+id/linearLayout">
-			<LinearLayout
-				android:layout_width="match_parent"
-				android:layout_height="wrap_content"
-				android:orientation="horizontal"
-				android:weightSum="2">
-
-				<TextView
-					android:id="@+id/partner_name"
-					android:layout_width="0dp"
-					android:layout_height="wrap_content"
-					android:layout_weight="1"
-					android:gravity="center"
-					android:textColor="@android:color/black"
-					android:textSize="16sp"
-					android:textStyle="bold"/>
-
-				<View
-					android:layout_width="3dp"
-					android:layout_height="match_parent"/>
-
-				<TextView
-					android:id="@+id/user_name"
-					android:layout_width="0dp"
-					android:layout_height="wrap_content"
-					android:layout_weight="1"
-					android:gravity="center"
-					android:textColor="@android:color/black"
-					android:textSize="16sp"
-					android:textStyle="bold"/>
-			</LinearLayout>
-			<LinearLayout
-				android:layout_width="match_parent"
-				android:layout_height="wrap_content"
-				android:orientation="horizontal">
-				<TextView
-					android:id="@+id/rtt_incoming_view"
-					android:layout_width="match_parent"
-					android:layout_height="120dp"
-					android:layout_weight="1"
-					android:background="@android:color/black"
-					android:textColor="@android:color/white"
-					android:singleLine="false"
-					android:scrollbars="vertical"
-					android:paddingLeft="2dp"
-					android:paddingRight="2dp"/>
-				<View
-					android:layout_width="3dp"
-					android:layout_height="match_parent"
-					android:background="@android:color/white"/>
-				<TextView
-					android:id="@+id/rtt_outgoing_view"
-					android:layout_width="match_parent"
-					android:layout_height="120dp"
-					android:layout_weight="1"
-					android:background="@android:color/black"
-					android:textColor="@android:color/white"
-					android:singleLine="false"
-					android:scrollbars="vertical"
-					android:paddingLeft="2dp"
-					android:paddingRight="2dp"/>
-			</LinearLayout>
-			<EditText
-				android:id="@+id/rtt_input_field"
-				android:layout_width="match_parent"
-				android:layout_height="wrap_content"
-				android:layout_weight="1"
-				android:singleLine="true"
-				android:textColor="@android:color/black"/>
-		</LinearLayout>
 	    
 	    <LinearLayout
 	        android:layout_alignParentBottom="true"

--- a/res/layout-sw720dp-land/incall.xml
+++ b/res/layout-sw720dp-land/incall.xml
@@ -51,6 +51,82 @@
         android:layout_marginBottom="150dp"
         android:layout_centerInParent="true" />
 
+	<LinearLayout
+		android:id="@+id/rtt_container"
+		android:visibility="gone"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:orientation="vertical"
+		android:layout_alignParentBottom="true"
+		android:layout_alignParentLeft="true"
+		android:layout_alignParentRight="true">
+		<LinearLayout
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:orientation="horizontal"
+			android:weightSum="2">
+
+			<TextView
+				android:id="@+id/partner_name"
+				android:layout_width="0dp"
+				android:layout_height="wrap_content"
+				android:layout_weight="1"
+				android:gravity="center"
+				style="@style/RttHeaderTextStyle" />
+
+			<View
+				android:layout_width="3dp"
+				android:layout_height="match_parent"/>
+
+			<TextView
+				android:id="@+id/user_name"
+				android:layout_width="0dp"
+				android:layout_height="wrap_content"
+				android:layout_weight="1"
+				android:gravity="center"
+				style="@style/RttHeaderTextStyle" />
+		</LinearLayout>
+		<LinearLayout
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:orientation="horizontal">
+			<TextView
+				android:id="@+id/rtt_incoming_view"
+				android:layout_width="match_parent"
+				android:layout_height="120dp"
+				android:layout_weight="1"
+				android:background="#B0000000"
+				android:singleLine="false"
+				android:scrollbars="vertical"
+				android:paddingLeft="2dp"
+				android:paddingRight="2dp"
+				style="@style/RttTextStyle"/>
+			<View
+				android:layout_width="3dp"
+				android:layout_height="match_parent"
+				android:background="@android:color/white"/>
+			<TextView
+				android:id="@+id/rtt_outgoing_view"
+				android:layout_width="match_parent"
+				android:layout_height="120dp"
+				android:layout_weight="1"
+				android:background="#B0000000"
+				android:singleLine="false"
+				android:scrollbars="vertical"
+				android:paddingLeft="2dp"
+				android:paddingRight="2dp"
+				style="@style/RttTextStyle"/>
+		</LinearLayout>
+		<EditText
+			android:id="@+id/rtt_input_field"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:layout_weight="1"
+			android:singleLine="true"
+			android:background="@android:color/black"
+			android:textColor="@android:color/white"/>
+	</LinearLayout>
+	
     <RelativeLayout 
         android:id="@+id/menu"
         android:layout_width="match_parent"
@@ -147,86 +223,6 @@
 	            android:textColor="@drawable/text_incall_button_color" />
 	        
 	    </LinearLayout>
-
-		<LinearLayout
-			android:id="@+id/rtt_container"
-			android:visibility="gone"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			android:orientation="vertical"
-			android:layout_alignParentBottom="true"
-			android:layout_toRightOf="@+id/left_menu"
-			android:layout_toLeftOf="@+id/linearLayout"
-			android:layout_toStartOf="@+id/linearLayout">
-			<LinearLayout
-				android:layout_width="match_parent"
-				android:layout_height="wrap_content"
-				android:orientation="horizontal"
-				android:weightSum="2">
-
-				<TextView
-					android:id="@+id/partner_name"
-					android:layout_width="0dp"
-					android:layout_height="wrap_content"
-					android:layout_weight="1"
-					android:gravity="center"
-					android:textColor="@android:color/black"
-					android:textSize="16sp"
-					android:textStyle="bold"/>
-
-				<View
-					android:layout_width="3dp"
-					android:layout_height="match_parent"/>
-
-				<TextView
-					android:id="@+id/user_name"
-					android:layout_width="0dp"
-					android:layout_height="wrap_content"
-					android:layout_weight="1"
-					android:gravity="center"
-					android:textColor="@android:color/black"
-					android:textSize="16sp"
-					android:textStyle="bold"/>
-			</LinearLayout>
-			<LinearLayout
-				android:layout_width="match_parent"
-				android:layout_height="wrap_content"
-				android:orientation="horizontal">
-				<TextView
-					android:id="@+id/rtt_incoming_view"
-					android:layout_width="match_parent"
-					android:layout_height="150dp"
-					android:layout_weight="1"
-					android:background="@android:color/black"
-					android:textColor="@android:color/white"
-					android:singleLine="false"
-					android:scrollbars="vertical"
-					android:paddingLeft="2dp"
-					android:paddingRight="2dp"/>
-				<View
-					android:layout_width="3dp"
-					android:layout_height="match_parent"
-					android:background="@android:color/white"/>
-				<TextView
-					android:id="@+id/rtt_outgoing_view"
-					android:layout_width="match_parent"
-					android:layout_height="150dp"
-					android:layout_weight="1"
-					android:background="@android:color/black"
-					android:textColor="@android:color/white"
-					android:singleLine="false"
-					android:scrollbars="vertical"
-					android:paddingLeft="2dp"
-					android:paddingRight="2dp"/>
-			</LinearLayout>
-			<EditText
-				android:id="@+id/rtt_input_field"
-				android:layout_width="match_parent"
-				android:layout_height="wrap_content"
-				android:layout_weight="1"
-				android:singleLine="true"
-				android:textColor="@android:color/black"/>
-		</LinearLayout>
 	    
 	    <LinearLayout
 			android:id="@+id/linearLayout"

--- a/res/layout/incall.xml
+++ b/res/layout/incall.xml
@@ -54,6 +54,82 @@
         android:layout_centerVertical="true"/>
 
     <LinearLayout
+        android:id="@+id/rtt_container"
+        android:visibility="gone"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentRight="true">
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:weightSum="2">
+
+            <TextView
+                android:id="@+id/partner_name"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="center"
+                style="@style/RttHeaderTextStyle" />
+
+            <View
+                android:layout_width="3dp"
+                android:layout_height="match_parent"/>
+
+            <TextView
+                android:id="@+id/user_name"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="center"
+                style="@style/RttHeaderTextStyle" />
+        </LinearLayout>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+            <TextView
+                android:id="@+id/rtt_incoming_view"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:layout_weight="1"
+                android:background="#B0000000"
+                android:singleLine="false"
+                android:scrollbars="vertical"
+                android:paddingLeft="2dp"
+                android:paddingRight="2dp"
+                style="@style/RttTextStyle"/>
+            <View
+                android:layout_width="3dp"
+                android:layout_height="match_parent"
+                android:background="@android:color/white"/>
+            <TextView
+                android:id="@+id/rtt_outgoing_view"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:layout_weight="1"
+                android:background="#B0000000"
+                android:singleLine="false"
+                android:scrollbars="vertical"
+                android:paddingLeft="2dp"
+                android:paddingRight="2dp"
+                style="@style/RttTextStyle"/>
+        </LinearLayout>
+        <EditText
+            android:id="@+id/rtt_input_field"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:singleLine="true"
+            android:background="@android:color/black"
+            android:textColor="@android:color/white"/>
+    </LinearLayout>
+    
+    <LinearLayout
         android:id="@+id/menu"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -303,80 +379,6 @@
                 android:background="@drawable/dialer_alt" />
             
         </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/rtt_container"
-            android:visibility="gone"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-	        <LinearLayout
-		        android:layout_width="match_parent"
-		        android:layout_height="wrap_content"
-		        android:orientation="horizontal"
-		        android:weightSum="2">
-		        <TextView
-			        android:id="@+id/partner_name"
-			        android:layout_width="0dp"
-			        android:layout_height="wrap_content"
-			        android:layout_weight="1"
-			        android:gravity="center"
-			        android:textColor="@android:color/white"
-			        android:textSize="14sp"
-			        android:textStyle="bold"/>
-		        <View
-			        android:layout_width="3dp"
-			        android:layout_height="match_parent"/>
-		        <TextView
-			        android:id="@+id/user_name"
-			        android:layout_width="0dp"
-			        android:layout_height="wrap_content"
-			        android:layout_weight="1"
-			        android:gravity="center"
-			        android:textColor="@android:color/white"
-			        android:textSize="14sp"
-			        android:textStyle="bold"/>
-	        </LinearLayout>
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
-                <TextView
-                    android:id="@+id/rtt_incoming_view"
-                    android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:layout_weight="1"
-                    android:background="@android:color/black"
-                    android:textColor="@android:color/white"
-                    android:singleLine="false"
-                    android:scrollbars="vertical"
-                    android:paddingLeft="2dp"
-                    android:paddingRight="2dp"/>
-	            <View
-		            android:layout_width="3dp"
-		            android:layout_height="match_parent"
-		            android:background="@android:color/white"/>
-                <TextView
-                    android:id="@+id/rtt_outgoing_view"
-                    android:layout_width="match_parent"
-                    android:layout_height="60dp"
-                    android:layout_weight="1"
-                    android:background="@android:color/black"
-                    android:textColor="@android:color/white"
-                    android:singleLine="false"
-                    android:scrollbars="vertical"
-                    android:paddingLeft="2dp"
-                    android:paddingRight="2dp"/>
-            </LinearLayout>
-            <EditText
-                android:id="@+id/rtt_input_field"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:singleLine="true"
-                android:textColor="@android:color/white"/>
-        </LinearLayout>
-
 
     </LinearLayout>
 

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -5,4 +5,19 @@
     <style name="NoTitle" parent="android:Theme.NoTitleBar" />
     <style name="FullScreen" parent="android:Theme.NoTitleBar.Fullscreen" />
 
+    <style name="RttTextStyle">
+        <item name="android:textColor">#FFFFFF</item>
+        <item name="android:textSize">16sp</item>
+    </style>
+
+    <style name="RttHeaderTextStyle">
+        <item name="android:textColor">@android:color/black</item>
+        <item name="android:textSize">16sp</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:shadowColor">@android:color/white</item>
+        <item name="android:shadowRadius">1.5</item>
+        <item name="android:shadowDx">1</item>
+        <item name="android:shadowDy">1</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
Calls without video currently get stuck on the Ringing screen and therefore cannot access the RTT UI.
Note that this means that **text is not usable at all unless video is enabled**.

The RTT UI is now separate from the popup menu, so that it's always visible at the bottom of the screen. The text background has been made semi-transparent since it would otherwise completely block part of the video.
