### PR TITLE
VATRP-1667 Android: Update client to has registration timeout of 280 seconds

### DIFF
--- a/src/org/linphone/setup/JsonConfig.java
+++ b/src/org/linphone/setup/JsonConfig.java
@@ -253,7 +253,7 @@ public class JsonConfig {
 
 	public final static String json = "{\n" +
 			"  \"version\": 1,\n" +
-			"  \"expiration_time\": 3600,\n" +
+			"  \"expiration_time\": 280,\n" +
 			"  \"configuration_auth_password\": \"\",\n" +
 			"  \"configuration_auth_expiration\": -1,\n" +
 			"  \"sip_registration_maximum_threshold\": 10,\n" +

--- a/src/org/linphone/setup/SetupActivity.java
+++ b/src/org/linphone/setup/SetupActivity.java
@@ -470,7 +470,7 @@ public class SetupActivity extends FragmentActivity implements OnClickListener {
 		.setDomain(domain)
 		.setUserId(userId)
 		.setPassword(password)
-		.setExpires("3600");
+		.setExpires("280");
 		Log.d("isMainAccountLinphoneDotOrg=" + isMainAccountLinphoneDotOrg);
 		Log.d("useLinphoneDotOrgCustomPorts=" + useLinphoneDotOrgCustomPorts);
 		if (isMainAccountLinphoneDotOrg && useLinphoneDotOrgCustomPorts) {


### PR DESCRIPTION
Android: Update client to has registration timeout of 280 seconds
