### PR TITLE
VATRP-2016 Android: App crashing on tablet when unselecting camera preview (out of call selfview).

### DIFF
--- a/src/org/linphone/DialerFragment.java
+++ b/src/org/linphone/DialerFragment.java
@@ -491,11 +491,17 @@ public class DialerFragment extends Fragment {
 
 			Log.d("Phone orientation changed to ", degrees);
 			lastDeviceAngle = degrees;
-			cameraPreview.removeAllViews();
-			mPreview.surfaceDestroyed(mPreview.getHolder());
-			mPreview = new CameraPreview(myContext, mCamera);
-			cameraPreview.addView(mPreview);
 
+
+			//Added quick crash fix to when unselecting camera preview prevent app from crashing.
+			try {
+				cameraPreview.removeAllViews();
+				mPreview.surfaceDestroyed(mPreview.getHolder());
+				mPreview = new CameraPreview(myContext, mCamera);
+				cameraPreview.addView(mPreview);
+			}catch(Throwable e){
+				e.printStackTrace();
+			}
 		}
 	}
 	@Override


### PR DESCRIPTION
Android: App crashing on tablet when unselecting camera preview (out of call selfview).
