### PR TITLE
VATRP-1807 Android: Send user back to login when invalid username or password is entered.

### DIFF
--- a/src/org/linphone/LinphoneActivity.java
+++ b/src/org/linphone/LinphoneActivity.java
@@ -288,6 +288,7 @@ public class LinphoneActivity extends FragmentActivity implements OnClickListene
 					}
 					if (proxy.getError() == Reason.Unauthorized) {
 						displayCustomToast(getString(R.string.error_unauthorized), Toast.LENGTH_LONG);
+						go_back_to_login();
 					}
 					if (proxy.getError() == Reason.IOError) {
 						displayCustomToast(getString(R.string.error_io_error), Toast.LENGTH_LONG);


### PR DESCRIPTION
-added change send user back to login even when receiving unauthorized.
