### PR TITLE
VATRP-2256  Android: Remove Debug option from Summary

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -481,8 +481,7 @@
   <string name="pref_summary_send_tss">Send TSS</string>
   <string name="pref_summary_show_advanced_key">pref_summary_show_advanced_key</string>
   <string name="pref_summary_show_advanced">Show Advanced</string>
-  <string name="pref_summary_show_debug_key">pref_summary_show_debug_key</string>
-  <string name="pref_summary_show_debug">Show Debug</string>
+
 <!-- Copyright (C) 2013 The Android Open Source Project
 
      Licensed under the Apache License, Version 2.0 (the "License");

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -93,9 +93,7 @@
 		<Preference
 			android:title="@string/pref_summary_show_advanced"
 			android:key="@string/pref_summary_show_advanced_key"/>
-		<Preference
-			android:title="@string/pref_summary_show_debug"
-			android:key="@string/pref_summary_show_debug_key"/>
+
 	</PreferenceScreen>
 
     <Preference


### PR DESCRIPTION
Android: Remove Debug option from Summary
