### PR TITLE
VATRP-2295 Android: Settings,Remove SIP Encryption link to TCP or TLS…

### DIFF
--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -8,9 +8,11 @@
 	<CheckBoxPreference
 		android:title="@string/pref_autostart"
 		android:key="@string/pref_autostart_key"/>
+	<!--
 	<CheckBoxPreference
 		android:title="@string/pref_general_sip_encryption"
 		android:key="@string/pref_general_sip_encryption_key"/>
+		-->
 	<CheckBoxPreference
 		android:title="@string/pref_wifi_only"
 		android:key="@string/pref_wifi_only_key"/>

--- a/src/org/linphone/SettingsFragment.java
+++ b/src/org/linphone/SettingsFragment.java
@@ -776,8 +776,8 @@ public class SettingsFragment extends PreferencesListFragment {
 	private void initGeneralSettings(){
 		((CheckBoxPreference)findPreference(getString(R.string.pref_autostart_key))).setChecked(mPrefs.isAutoStartEnabled());
 
-		boolean isSipEncryptionEnabled = false; //VATRP-1007
-		((CheckBoxPreference)findPreference(getString(R.string.pref_general_sip_encryption_key))).setChecked(isSipEncryptionEnabled);
+//		boolean isSipEncryptionEnabled = false; //VATRP-1007
+//		((CheckBoxPreference)findPreference(getString(R.string.pref_general_sip_encryption_key))).setChecked(isSipEncryptionEnabled);
 
 		((CheckBoxPreference) findPreference(getString(R.string.pref_wifi_only_key))).setChecked(mPrefs.isWifiOnlyEnabled());
 
@@ -807,21 +807,21 @@ public class SettingsFragment extends PreferencesListFragment {
 			}
 		});
 
-		//Todo: VATRP-1007 -- Add SIP Encryption logic on toggle
-		findPreference(getString(R.string.pref_general_sip_encryption_key)).setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
-			@Override
-			public boolean onPreferenceChange(Preference preference, Object newValue) {
-				boolean value = (Boolean) newValue;
-				if(value){
-					mPrefs.setAccountTransport(n, getString(R.string.pref_transport_tls_key));
-					mPrefs.setAccountProxy(n, mPrefs.getAccountProxy(n).replace("5060","5061"));
-				}else{
-					mPrefs.setAccountTransport(n, getString(R.string.pref_transport_tcp_key));
-					mPrefs.setAccountProxy(n, mPrefs.getAccountProxy(n).replace("5061","5060"));
-				}
-				return true;
-			}
-		});
+//
+//		findPreference(getString(R.string.pref_general_sip_encryption_key)).setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
+//			@Override
+//			public boolean onPreferenceChange(Preference preference, Object newValue) {
+//				boolean value = (Boolean) newValue;
+//				if(value){
+//					mPrefs.setAccountTransport(n, getString(R.string.pref_transport_tls_key));
+//					mPrefs.setAccountProxy(n, mPrefs.getAccountProxy(n).replace("5060","5061"));
+//				}else{
+//					mPrefs.setAccountTransport(n, getString(R.string.pref_transport_tcp_key));
+//					mPrefs.setAccountProxy(n, mPrefs.getAccountProxy(n).replace("5061","5060"));
+//				}
+//				return true;
+//			}
+//		});
 
 		findPreference(getString(R.string.pref_wifi_only_key)).setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
 			@Override


### PR DESCRIPTION
VATRP-2295
Android: Settings,Remove SIP Encryption link to TCP or TLS if required
