### PR TITLE
Double registration pop issue resolved.

### DIFF
--- a/src/org/linphone/LinphoneActivity.java
+++ b/src/org/linphone/LinphoneActivity.java
@@ -117,6 +117,8 @@ public class LinphoneActivity extends FragmentActivity implements OnClickListene
 	private static final int CALL_ACTIVITY = 19;
     private static final int CHAT_ACTIVITY = 21;
 
+	private static boolean first_launch_boolean=true;
+
 	private static LinphoneActivity instance;
 
 	private StatusFragment statusFragment;
@@ -204,9 +206,14 @@ public class LinphoneActivity extends FragmentActivity implements OnClickListene
 			wizard.putExtra("Domain", LinphoneManager.getInstance().wizardLoginViewDomain);
 			startActivityForResult(wizard, REMOTE_PROVISIONING_LOGIN_ACTIVITY);
 		} else if (LinphonePreferences.instance().isFirstLaunch() || LinphonePreferences.instance().getAccountCount() == 0) {
+
+			//This is where the login screen is launched of first run, after accept legal release
+			if(first_launch_boolean==true) {
 				startActivityForResult(new Intent().setClass(this, SetupActivity.class), FIRST_LOGIN_ACTIVITY);
 				LinphonePreferences.instance().firstLaunchSuccessful();
-            
+				first_launch_boolean=false;
+			}
+
 		}
         
         


### PR DESCRIPTION
Double registration pop issue resolved. On initial installation of the app on some devices mainly tablet, after accepting the legal release. Two pop-ups were launching for the initial login. This gave the appearance that the initial login didn't work, which it did.
