### PR TITLE
VATRP-2651 Android: Allow selecting login button on enter press from password field

### DIFF
--- a/res/layout/login_provider.xml
+++ b/res/layout/login_provider.xml
@@ -146,6 +146,7 @@
                 android:autoText="false"
                 android:paddingLeft="30dp"
                 android:singleLine="true"
+                android:nextFocusDown="@+id/btn_prv_login"
                 android:imeOptions="actionNext"/>
         </LinearLayout>
 

--- a/src/org/linphone/LinphoneActivity.java
+++ b/src/org/linphone/LinphoneActivity.java
@@ -22,6 +22,7 @@ import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.app.ProgressDialog;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -108,6 +109,9 @@ import static org.linphone.LinphoneManager.getLc;
  * @author Sylvain Berfini
  */
 public class LinphoneActivity extends FragmentActivity implements OnClickListener, ContactPicked {
+
+	public static ProgressDialog generic_ace_loading_dialog;
+
 	public static final String PREF_FIRST_LAUNCH = "pref_first_launch";
 	public static Context ctx;
 	public static Activity act;

--- a/src/org/linphone/setup/JsonConfig.java
+++ b/src/org/linphone/setup/JsonConfig.java
@@ -1,18 +1,23 @@
 package org.linphone.setup;
 
+import android.app.AlertDialog;
+import android.app.ProgressDialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.os.AsyncTask;
 import android.os.Build;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.linphone.LinphoneActivity;
 import org.linphone.LinphoneManager;
 import org.linphone.LinphonePreferences;
 import org.linphone.core.LinphoneAddress;
 import org.linphone.core.LinphoneCore;
 import org.linphone.core.LinphoneCoreException;
 import org.linphone.core.PayloadType;
+import org.linphone.mediastream.Log;
 import org.xbill.DNS.Lookup;
 import org.xbill.DNS.Record;
 import org.xbill.DNS.SRVRecord;
@@ -326,6 +331,7 @@ public class JsonConfig {
 			errorMsg = "Failed to Login";
 		}
 
+
 		@Override
 		protected JsonConfig doInBackground(Void... params) {
 			Record[] records;// = new Record[0];
@@ -370,16 +376,47 @@ public class JsonConfig {
 			return null;
 		}
 
+		@Override
+		protected void onPreExecute() {
+			super.onPreExecute();
+			Log.d("Starting autoconfig download");
+			LinphoneActivity.instance().generic_ace_loading_dialog = new ProgressDialog(LinphoneActivity.instance());
+			LinphoneActivity.instance().generic_ace_loading_dialog.setCancelable(true);
+			LinphoneActivity.instance().generic_ace_loading_dialog.setMessage("Loading Auto Configuration Based on User...");
+			LinphoneActivity.instance().generic_ace_loading_dialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);
+			LinphoneActivity.instance().generic_ace_loading_dialog.setProgress(0);
+			LinphoneActivity.instance().generic_ace_loading_dialog.show();
 
+		}
 		@Override
 		protected void onPostExecute(JsonConfig res) {
 			super.onPostExecute(res);
 			if (res != null) {
-				if (listener != null)
+				if (listener != null) {
 					listener.onParsed(res);
+					LinphoneActivity.instance().generic_ace_loading_dialog.cancel();
+					new AlertDialog.Builder(LinphoneActivity.instance())
+							.setMessage("Auto-Configuration")
+							.setTitle("Configuration Loaded Successfully")
+							.setPositiveButton("OK", new DialogInterface.OnClickListener() {
+								@Override
+								public void onClick(DialogInterface dialogInterface, int i) {
+								}
+							}).show();
+				}
 			} else {
-				if (listener != null)
+				if (listener != null) {
 					listener.onFailed(errorMsg);
+					LinphoneActivity.instance().generic_ace_loading_dialog.cancel();
+					new AlertDialog.Builder(LinphoneActivity.instance())
+							.setMessage("Auto-Configuration")
+							.setTitle("Configuration Not Loaded")
+							.setPositiveButton("OK", new DialogInterface.OnClickListener() {
+								@Override
+								public void onClick(DialogInterface dialogInterface, int i) {
+								}
+							}).show();
+				}
 			}
 
 		}

--- a/src/org/linphone/setup/JsonConfig.java
+++ b/src/org/linphone/setup/JsonConfig.java
@@ -396,8 +396,8 @@ public class JsonConfig {
 					listener.onParsed(res);
 					LinphoneActivity.instance().generic_ace_loading_dialog.cancel();
 					new AlertDialog.Builder(LinphoneActivity.instance())
-							.setMessage("Auto-Configuration")
-							.setTitle("Configuration Loaded Successfully")
+							.setMessage("Configuration Loaded Successfully")
+							.setTitle("Auto-Configuration")
 							.setPositiveButton("OK", new DialogInterface.OnClickListener() {
 								@Override
 								public void onClick(DialogInterface dialogInterface, int i) {
@@ -409,8 +409,8 @@ public class JsonConfig {
 					listener.onFailed(errorMsg);
 					LinphoneActivity.instance().generic_ace_loading_dialog.cancel();
 					new AlertDialog.Builder(LinphoneActivity.instance())
-							.setMessage("Auto-Configuration")
-							.setTitle("Configuration Not Loaded")
+							.setMessage("Configuration Not Loaded")
+							.setTitle("Auto-Configuration")
 							.setPositiveButton("OK", new DialogInterface.OnClickListener() {
 								@Override
 								public void onClick(DialogInterface dialogInterface, int i) {


### PR DESCRIPTION
VATRP-2651
Android: Allow selecting login button on enter press from password field

This will significantly speed up development time on keyboard accessed devices, and allow for Android TV machines to quickly login without need a mouse.
