### PR TITLE
VATRP- 3056: Android/ Incall camera mute

### DIFF
--- a/src/org/linphone/InCallActivity.java
+++ b/src/org/linphone/InCallActivity.java
@@ -319,7 +319,7 @@ public class InCallActivity extends FragmentActivity implements OnClickListener 
 					VideoCallFragment.cameraCover.setImageResource(R.drawable.camera_mute);
 					VideoCallFragment.cameraCover.setVisibility(View.VISIBLE);
 
-				}else if(info.getHeader("action").equals("isCameraMuted") || info.getHeader("action").equals("camera_mute_on")){
+				}else if(info.getHeader("action").equals("camera_mute_on")){
 					VideoCallFragment.cameraCover.setVisibility(View.GONE);
 
 				}
@@ -1467,51 +1467,46 @@ public class InCallActivity extends FragmentActivity implements OnClickListener 
 	}
 
 
-	private void setCameraMute(boolean enabled)	{
+	private void setCameraMute(boolean muted)	{
 
-		isCameraMuted = enabled;
+		isCameraMuted = muted;
 
-		LinphoneInfoMessage message = LinphoneManager.getLc().createInfoMessage();
+		final LinphoneInfoMessage message = LinphoneManager.getLc().createInfoMessage();
 		final LinphoneCall call = LinphoneManager.getLc().getCurrentCall();
 
-		if (enabled) {
-			message.addHeader("action", "camera_mute_off");
-			LinphoneManager.getLc().setPreviewWindow(null);
-		} else {
-			message.addHeader("action", "isCameraMuted");
+		if (!muted) {
+			message.addHeader("action", "camera_mute_on");
+			if(VideoCallFragment.mCaptureView!=null)
+				VideoCallFragment.mCaptureView.setVisibility(View.VISIBLE);
 			LinphoneManager.getLc().setPreviewWindow(VideoCallFragment.mCaptureView);
+		} else {
+			message.addHeader("action", "camera_mute_off");
+			if(VideoCallFragment.mCaptureView!=null)
+				VideoCallFragment.mCaptureView.setVisibility(View.INVISIBLE);
+			LinphoneManager.getLc().setPreviewWindow(null);
 		}
 
-		call.sendInfoMessage(message);
+
+		video.postDelayed(new Runnable() {
+			@Override
+			public void run() {
+				call.sendInfoMessage(message);
+
+			}
+		}, 3000);
 
 		//This line remains for other platforms. To force the video to unfreeze.
 
 	}
+	public boolean isCameraMuted()
+	{
+		return  isCameraMuted;
+	}
 
 	public void toggleCamera_mute() {
-		if (isCameraMuted) {
-			video.setSelected(false);
-
-			LinphoneInfoMessage message = LinphoneManager.getLc().createInfoMessage();
-			message.addHeader("action", "isCameraMuted");
-			final LinphoneCall call = LinphoneManager.getLc().getCurrentCall();
-			call.sendInfoMessage(message);
-
-			//This line remains for other platforms. To force the video to unfreeze.
-			LinphoneManager.getLc().setPreviewWindow(VideoCallFragment.mCaptureView);
-			isCameraMuted = false;
-		} else {
-			video.setSelected(true);
-
-			LinphoneInfoMessage message = LinphoneManager.getLc().createInfoMessage();
-			message.addHeader("action", "camera_mute_off");
-			final LinphoneCall call = LinphoneManager.getLc().getCurrentCall();
-			call.sendInfoMessage(message);
-
-			//This line remains for other platforms. To force the video to freeze.
-			LinphoneManager.getLc().setPreviewWindow(null);
-			isCameraMuted = true;
-		}
+		video.setSelected(!isCameraMuted);
+		setCameraMute(!isCameraMuted);
+		
 	}
 
 	public void displayCustomToast(final String message, final int duration) {

--- a/src/org/linphone/VideoCallFragment.java
+++ b/src/org/linphone/VideoCallFragment.java
@@ -137,7 +137,17 @@ public class VideoCallFragment extends Fragment implements OnGestureListener, On
 		if(isSelfViewEnabled){
 			fixZOrder(mVideoView, mCaptureView);
 		}
-		LinphoneManager.getLc().setPreviewWindow(mCaptureView);
+
+		if(!((InCallActivity)getActivity()).isCameraMuted())
+		{
+			LinphoneManager.getLc().setPreviewWindow(mCaptureView);
+		}
+		else
+		{
+			LinphoneManager.getLc().setPreviewWindow(null);
+			mCaptureView.setVisibility(View.INVISIBLE);
+		}
+
 		androidVideoWindowImpl = new AndroidVideoWindowImpl(mVideoView, mCaptureView, new AndroidVideoWindowImpl.VideoWindowListener() {
 			@Override
 			public void onVideoRenderingSurfaceReady(AndroidVideoWindowImpl vw, SurfaceView surface) {
@@ -157,7 +167,8 @@ public class VideoCallFragment extends Fragment implements OnGestureListener, On
 			public void onVideoPreviewSurfaceReady(AndroidVideoWindowImpl vw, SurfaceView surface) {
 				mCaptureView = surface;
 				//	isH263();
-				LinphoneManager.getLc().setPreviewWindow(mCaptureView);
+				if(!((InCallActivity) getActivity()).isCameraMuted())
+					LinphoneManager.getLc().setPreviewWindow(mCaptureView);
 			}
 
 			@Override


### PR DESCRIPTION
1. action field of sip message for camera mute is changed to work with other platforms.
2. selfview is hidden when camera is muted
