### PR TITLE
VATRP-3159 (Fix for tablets)

### DIFF
--- a/res/raw-sw600dp/linphonerc_default
+++ b/res/raw-sw600dp/linphonerc_default
@@ -56,7 +56,7 @@ mime=VP8
 rate=90000
 enabled=1
 
-[video_codec_4]
+[video_codec_3]
 mime=MP4V-ES
 rate=90000
 enabled=0


### PR DESCRIPTION
Android: Regression MPEG4 is being offered again.
