### PR TITLE
VATRP-3428: Android/ Changed remove contact texts

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -327,7 +327,7 @@
   <string name="button_new_chat">New conversation</string>
   <string name="button_edit">Edit</string>
   <string name="button_cancel">Cancel</string>
-  <string name="button_ok">Okay</string>
+  <string name="button_ok">Ok</string>
   <string name="button_back">Back</string>
   <string name="button_all_contacts">All</string>
   <string name="button_import_export_contact">Import/Export</string>
@@ -370,7 +370,7 @@
   <string name="pref_image_sharing_server_title">Sharing server</string>
   <string name="pref_remote_provisioning_title">Remote provisioning</string>
   <string name="delete_contact">Delete</string>
-  <string name="delete_contact_dialog">This contact will be deleted.</string>
+  <string name="delete_contact_dialog">Are you sure you want to remove/delete contact?</string>
   <string name="sip_address">SIP address</string>
   <string name="phone_number">Phone number</string>
   <string name="contact_first_name">First name</string>


### PR DESCRIPTION
When removing a Contact from the Phonebook, app doesn't prompt "Are you sure you want to remove/delete contact?".
And set two buttons to "Cancel", "OK".
