### PR TITLE
VATRP-3329: Pressing Video Privacy is really slow.

### DIFF
--- a/src/org/linphone/InCallActivity.java
+++ b/src/org/linphone/InCallActivity.java
@@ -1508,13 +1508,7 @@ public class InCallActivity extends FragmentActivity implements OnClickListener 
 		}
 
 
-		video.postDelayed(new Runnable() {
-			@Override
-			public void run() {
-				call.sendInfoMessage(message);
-
-			}
-		}, 3000);
+		call.sendInfoMessage(message);
 
 		//This line remains for other platforms. To force the video to unfreeze.
 


### PR DESCRIPTION
It takes three(ish) seconds for video privacy to actually be applied.
