### PR TITLE
VATRP-3739: Incoming call timeout

### DIFF
--- a/res/raw-sw600dp/linphonerc_factory
+++ b/res/raw-sw600dp/linphonerc_factory
@@ -7,7 +7,7 @@ mtu=1300
 
 [sip]
 guess_hostname=1
-inc_timeout=15
+inc_timeout=300
 register_only_when_network_is_up=1
 auto_net_state_mon=0
 auto_answer_replacing_calls=1

--- a/res/raw/linphonerc_factory
+++ b/res/raw/linphonerc_factory
@@ -7,7 +7,7 @@ mtu=1300
 
 [sip]
 guess_hostname=1
-inc_timeout=15
+inc_timeout=300
 register_only_when_network_is_up=1
 auto_net_state_mon=0
 auto_answer_replacing_calls=1


### PR DESCRIPTION
Incoming call timeout is changed from 15 to 300 seconds.
