### PR TITLE
VATRP-3856 Android: Add try/catch to new torch flasher on call to prevent crash seen in hockeyapp

### DIFF
--- a/src/org/linphone/CameraPreviewTorch.java
+++ b/src/org/linphone/CameraPreviewTorch.java
@@ -6,8 +6,6 @@ import android.util.Log;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 
-import java.io.IOException;
-
 public class CameraPreviewTorch extends SurfaceView implements SurfaceHolder.Callback {
 	private SurfaceHolder mHolder;
 	private Camera mCamera;
@@ -18,10 +16,10 @@ public class CameraPreviewTorch extends SurfaceView implements SurfaceHolder.Cal
 
 		SurfaceHolder mHolder = preview.getHolder();
 		mHolder.addCallback(this);
-		mCamera = Camera.open();
 		try {
+			mCamera = Camera.open();
 			mCamera.setPreviewDisplay(mHolder);
-		} catch (IOException e) {
+		} catch (Throwable e) {
 			e.printStackTrace();
 		}
 	}


### PR DESCRIPTION
VATRP-3856 Android: Add try/catch to new torch flasher on call to prevent crash seen in hockeyapp
