### PR TITLE
VATRP-3906 Android: Not sending video when call from Windows to Android (ALL ANDROID VIDEO NEGOTIATION ISSUES)

### DIFF
--- a/src/org/linphone/LinphoneManager.java
+++ b/src/org/linphone/LinphoneManager.java
@@ -1098,6 +1098,7 @@ public class LinphoneManager implements LinphoneCoreListener, LinphoneChatMessag
 		if (state==State.CallEnd || state == State.CallReleased || state == State.Error){
 			if (mLc.getCallsNb() == 0) {
 				g.in_call_activity_suspended = false;
+				g.intial_call_update_sent = false;
 			}
 		}
 

--- a/src/org/linphone/StatusFragment.java
+++ b/src/org/linphone/StatusFragment.java
@@ -59,6 +59,7 @@ import org.linphone.core.PayloadType;
 import org.linphone.mediastream.Log;
 import org.linphone.ui.SlidingDrawer;
 import org.linphone.ui.SlidingDrawer.OnDrawerOpenListener;
+import org.linphone.vtcsecure.g;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -605,6 +606,9 @@ public class StatusFragment extends Fragment {
 									}
 									dl.setText(String.valueOf((int) videoStats.getDownloadBandwidth()) + " / " + (int) audioStats.getDownloadBandwidth() + " kbits/s");
 									ul.setText(String.valueOf((int) videoStats.getUploadBandwidth()) +  " / " + (int) audioStats.getUploadBandwidth() + " kbits/s");
+
+
+
 									ice.setText(videoStats.getIceState().toString());
 
 									videoResolutionLayout.setVisibility(View.VISIBLE);
@@ -622,6 +626,12 @@ public class StatusFragment extends Fragment {
 									getRoundTripDelay.setText(String.valueOf(videoStats.getRoundTripDelay()));
 									getSenderInterarrivalJitter.setText(String.valueOf(videoStats.getSenderInterarrivalJitter()));
 									getSenderLossRate.setText(String.valueOf(videoStats.getSenderLossRate()));
+
+									//Send one time call update during first status update to fix video negotiation issues.
+									if(!g.intial_call_update_sent) {
+										InCallActivity.instance().update_call();
+										g.intial_call_update_sent = true;
+									}
 
 								}
 							} else {

--- a/src/org/linphone/vtcsecure/g.java
+++ b/src/org/linphone/vtcsecure/g.java
@@ -29,4 +29,7 @@ public class g {
     public static boolean AudioMuted;
     public static boolean VideoCallPaused;
 
+    public static boolean intial_call_update_sent=false;
+
+
 }


### PR DESCRIPTION
VATRP-3906 Android: Not sending video when call from Windows to Android (ALL ANDROID VIDEO NEGOTIATION ISSUES)
