### PR TITLE
VATRP-3961 Android: Crash when app resumes after crash from hockeyapp logs see attached. Related to uninitialized analytics variable.

### DIFF
--- a/ace-android.iml
+++ b/ace-android.iml
@@ -97,6 +97,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-support" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/reload-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/restart-dex" />

--- a/src/org/linphone/InCallActivity.java
+++ b/src/org/linphone/InCallActivity.java
@@ -430,6 +430,7 @@ public class InCallActivity extends FragmentActivity implements OnClickListener 
 
 					}
 					stopOutgoingRingCount();
+
 				}
 
 				if (lc.getCallsNb() == 0) {
@@ -509,6 +510,7 @@ public class InCallActivity extends FragmentActivity implements OnClickListener 
 //						videoProgress.setVisibility(View.GONE);
 						status.refreshStatusItems(call, isVideoEnabled(call));
 					}
+					statusContainer.setVisibility(View.GONE);
 				}
 
 				refreshInCallActions();

--- a/src/org/linphone/LinphoneActivity.java
+++ b/src/org/linphone/LinphoneActivity.java
@@ -97,6 +97,7 @@ import org.linphone.setup.JsonConfig;
 import org.linphone.setup.RemoteProvisioningLoginActivity;
 import org.linphone.setup.SetupActivity;
 import org.linphone.ui.AddressText;
+import org.linphone.vtcsecure.GAUtils;
 import org.linphone.vtcsecure.LinphoneLocationManager;
 import org.linphone.vtcsecure.Utils;
 import org.linphone.vtcsecure.g;
@@ -789,6 +790,10 @@ public class LinphoneActivity extends FragmentActivity implements OnClickListene
 	}
 
 	private void changeCurrentFragment(FragmentsAvailable newFragmentType, Bundle extras, boolean withoutAnimation) {
+
+		if(g.analytics_tracker==null){
+			g.analytics_tracker=new GAUtils(getApplicationContext()).getInstance(getApplicationContext());
+		}
 		if (newFragmentType == currentFragment && newFragmentType != FragmentsAvailable.CHAT && newFragmentType != FragmentsAvailable.SETTINGS) {
 			return;
 		}

--- a/src/org/linphone/LinphoneLauncherActivity.java
+++ b/src/org/linphone/LinphoneLauncherActivity.java
@@ -65,7 +65,7 @@ public class LinphoneLauncherActivity extends Activity {
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		// Used to change for the lifetime of the app the name used to tag the logs
-		g.analytics_tracker = new GAUtils(getApplicationContext()).getInstance(getApplicationContext());
+
 
 
 		new Log(getResources().getString(R.string.app_name), !getResources().getBoolean(R.bool.disable_every_log));
@@ -92,13 +92,7 @@ public class LinphoneLauncherActivity extends Activity {
 		initFontSettings();
 
 
-		//Screen Hit
-		//Log.i(Log.TAG, "Setting screen name: LauncherScreen");
-		g.analytics_tracker.setScreenName("LauncherScreen");
 
-
-		//Event
-		g.analytics_tracker.send(this,"Action","App Launched",null,null);
 
 	}
 
@@ -148,6 +142,13 @@ public class LinphoneLauncherActivity extends Activity {
 		super.onResume();
 		//checkForCrashes();
 		//checkForUpdates();
+		g.analytics_tracker = new GAUtils(getApplicationContext()).getInstance(getApplicationContext());
+		//Screen Hit
+		//Log.i(Log.TAG, "Setting screen name: LauncherScreen");
+		g.analytics_tracker.setScreenName("LauncherScreen");
+
+		//Event
+		g.analytics_tracker.send(this,"Action","App Launched",null,null);
 	}
 	@Override
 	protected void onPause() {

--- a/src/org/linphone/LinphoneManager.java
+++ b/src/org/linphone/LinphoneManager.java
@@ -1098,6 +1098,7 @@ public class LinphoneManager implements LinphoneCoreListener, LinphoneChatMessag
 		if (state==State.CallEnd || state == State.CallReleased || state == State.Error){
 			if (mLc.getCallsNb() == 0) {
 				g.in_call_activity_suspended = false;
+				g.intial_call_update_sent = false;
 			}
 		}
 

--- a/src/org/linphone/StatusFragment.java
+++ b/src/org/linphone/StatusFragment.java
@@ -59,6 +59,7 @@ import org.linphone.core.PayloadType;
 import org.linphone.mediastream.Log;
 import org.linphone.ui.SlidingDrawer;
 import org.linphone.ui.SlidingDrawer.OnDrawerOpenListener;
+import org.linphone.vtcsecure.g;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -624,6 +625,16 @@ public class StatusFragment extends Fragment {
 									getRoundTripDelay.setText(String.valueOf(videoStats.getRoundTripDelay()));
 									getSenderInterarrivalJitter.setText(String.valueOf(videoStats.getSenderInterarrivalJitter()));
 									getSenderLossRate.setText(String.valueOf(videoStats.getSenderLossRate()));
+
+
+									try {
+										if (!g.intial_call_update_sent) {
+											InCallActivity.instance().update_call();
+											g.intial_call_update_sent = true;
+										}
+									}catch(Throwable e){
+										e.printStackTrace();
+									}
 
 								}
 							} else {

--- a/src/org/linphone/vtcsecure/g.java
+++ b/src/org/linphone/vtcsecure/g.java
@@ -29,4 +29,6 @@ public class g {
     public static boolean AudioMuted;
     public static boolean VideoCallPaused;
 
+    public static boolean intial_call_update_sent=false;
+
 }


### PR DESCRIPTION
VATRP-3961
Android: Crash when app resumes after crash from hockeyapp logs see attached. Related to uninitialized analytics variable.
