### PR TITLE
VATRP-3961 Android: Crash when app resumes after crash from hockeyapp logs see attached. Related to uninitialized analytics variable.

### DIFF
--- a/src/org/linphone/LinphoneActivity.java
+++ b/src/org/linphone/LinphoneActivity.java
@@ -97,6 +97,7 @@ import org.linphone.setup.JsonConfig;
 import org.linphone.setup.RemoteProvisioningLoginActivity;
 import org.linphone.setup.SetupActivity;
 import org.linphone.ui.AddressText;
+import org.linphone.vtcsecure.GAUtils;
 import org.linphone.vtcsecure.LinphoneLocationManager;
 import org.linphone.vtcsecure.Utils;
 import org.linphone.vtcsecure.g;
@@ -789,6 +790,10 @@ public class LinphoneActivity extends FragmentActivity implements OnClickListene
 	}
 
 	private void changeCurrentFragment(FragmentsAvailable newFragmentType, Bundle extras, boolean withoutAnimation) {
+
+		if(g.analytics_tracker==null){
+			g.analytics_tracker=new GAUtils(getApplicationContext()).getInstance(getApplicationContext());
+		}
 		if (newFragmentType == currentFragment && newFragmentType != FragmentsAvailable.CHAT && newFragmentType != FragmentsAvailable.SETTINGS) {
 			return;
 		}

--- a/src/org/linphone/LinphoneLauncherActivity.java
+++ b/src/org/linphone/LinphoneLauncherActivity.java
@@ -65,7 +65,7 @@ public class LinphoneLauncherActivity extends Activity {
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		// Used to change for the lifetime of the app the name used to tag the logs
-		g.analytics_tracker = new GAUtils(getApplicationContext()).getInstance(getApplicationContext());
+
 
 
 		new Log(getResources().getString(R.string.app_name), !getResources().getBoolean(R.bool.disable_every_log));
@@ -92,13 +92,7 @@ public class LinphoneLauncherActivity extends Activity {
 		initFontSettings();
 
 
-		//Screen Hit
-		//Log.i(Log.TAG, "Setting screen name: LauncherScreen");
-		g.analytics_tracker.setScreenName("LauncherScreen");
 
-
-		//Event
-		g.analytics_tracker.send(this,"Action","App Launched",null,null);
 
 	}
 
@@ -148,6 +142,13 @@ public class LinphoneLauncherActivity extends Activity {
 		super.onResume();
 		//checkForCrashes();
 		//checkForUpdates();
+		g.analytics_tracker = new GAUtils(getApplicationContext()).getInstance(getApplicationContext());
+		//Screen Hit
+		//Log.i(Log.TAG, "Setting screen name: LauncherScreen");
+		g.analytics_tracker.setScreenName("LauncherScreen");
+
+		//Event
+		g.analytics_tracker.send(this,"Action","App Launched",null,null);
 	}
 	@Override
 	protected void onPause() {


### PR DESCRIPTION
VATRP-3961
Android: Crash when app resumes after crash from hockeyapp logs see attached. Related to uninitialized analytics variable.
