### PR TITLE
VATRP-3970 Android: in call buttons will not hide when the user clicks on the screen

### DIFF
--- a/src/org/linphone/InCallActivity.java
+++ b/src/org/linphone/InCallActivity.java
@@ -1384,6 +1384,7 @@ public class InCallActivity extends FragmentActivity implements OnClickListener 
 		statusContainer.setOnClickListener(new OnClickListener() {
 			@Override
 			public void onClick(View v) {
+				statusContainer.setVisibility(View.GONE);
 				if(showStatusFlashing) {
 					stopStatusFlashing();
 				}


### PR DESCRIPTION
VATRP-3970 Android: in call buttons will not hide when the user clicks on the screen
