### PR TITLE
Added ace-android.iml to gitignore to keep development environment clean and prevent seeing unnecessary discrepancies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ WORK
 test_servers
 screenshot_*.png
 ace-android*.iml
+ace-android.iml


### PR DESCRIPTION
Added ace-android.iml to gitignore to keep development environment clean and prevent seeing unnecessary discrepancies.
